### PR TITLE
Package marker files are not executable

### DIFF
--- a/src/baldor/__init__.py
+++ b/src/baldor/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 from . import axis_angle
 from . import euler
 from . import quaternion


### PR DESCRIPTION
As per subject.

There are more files which can't be directly executed, but I wanted to first understand whether you had a reason for adding the shebang everywhere, so this PR only changes the `__init__.py` marker.
