### PR TITLE
numpy.float deprecated, use numpy.float64 instead

### DIFF
--- a/src/baldor/__init__.py
+++ b/src/baldor/__init__.py
@@ -9,10 +9,10 @@ import numpy as np
 X_AXIS = np.array([1., 0., 0.], dtype=np.float64)
 Y_AXIS = np.array([0., 1., 0.], dtype=np.float64)
 Z_AXIS = np.array([0., 0., 1.], dtype=np.float64)
-_MAX_FLOAT = np.maximum_sctype(np.float)
+_MAX_FLOAT = np.maximum_sctype(np.float64)
 # epsilon for testing whether a number is close to zero
-_FLOAT_EPS = np.finfo(np.float).eps
-_EPS = np.finfo(float).eps * 4.0
+_FLOAT_EPS = np.finfo(np.float64).eps
+_EPS = np.finfo(np.float64).eps * 4.0
 # axis sequences for Euler angles
 _NEXT_AXIS = [1, 2, 0, 1]
 # map axes strings to/from tuples of inner axis, parity, repetition, frame


### PR DESCRIPTION
Hi, I tried using baldor but it threw an error. The issue is `numpy.float` [was deprecated](https://numpy.org/devdocs/release/1.20.0-notes.html). This PR fixes the issue.